### PR TITLE
Cache & Redis Module

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 DATABASE_URL=postgres://lab:P@ssword@localhost:5432/practical-nestjs
 LOG_ENABLED=false
 
+REDIS_CACHE_ENABLED=true
+
 REDIS_URL=redis://localhost:6379
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/.env
+++ b/.env
@@ -1,2 +1,9 @@
 DATABASE_URL=postgres://lab:P@ssword@localhost:5432/practical-nestjs
 LOG_ENABLED=false
+
+REDIS_ENABLED=true
+REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_USERNAME=
+REDIS_PASSWORD=

--- a/.env
+++ b/.env
@@ -1,9 +1,6 @@
 DATABASE_URL=postgres://lab:P@ssword@localhost:5432/practical-nestjs
 LOG_ENABLED=false
 
-REDIS_ENABLED=true
 REDIS_URL=redis://localhost:6379
-REDIS_HOST=localhost
-REDIS_PORT=6379
 REDIS_USERNAME=
 REDIS_PASSWORD=

--- a/.env
+++ b/.env
@@ -2,5 +2,7 @@ DATABASE_URL=postgres://lab:P@ssword@localhost:5432/practical-nestjs
 LOG_ENABLED=false
 
 REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
 REDIS_USERNAME=
 REDIS_PASSWORD=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,10 +23,6 @@ services:
     volumes:
       - "redis-data:/root/redis"
       - "redis-config:/usr/local/etc/redis/redis.conf"
-    # environment:
-    #   - REDIS_PASSWORD=my-password
-    #   - REDIS_PORT=6379
-    #   - REDIS_DATABASES=16
     networks:
       - nestjs
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "ioredis": "^5.4.1",
     "jest": "^29.5.0",
     "pg": "^8.11.5",
     "prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "guid-typescript": "^1.0.9",
+    "redis": "^4.6.13",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^2.2.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "cache-manager": "^5.5.1",
+    "cache-manager-redis-yet": "^5.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "guid-typescript": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nestjs/testing": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",
     "@testcontainers/postgresql": "^10.8.2",
+    "@testcontainers/redis": "^10.9.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Get, Inject } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ConfigurationsService } from './building-blocks/infra/configurations/configurations.service';
+import { RedisService } from './building-blocks/infra/redis/redis.service';
 
 @Controller()
 export class AppController {
   constructor(
     private readonly appService: AppService,
-    @Inject(ConfigurationsService) private readonly _configurationService: ConfigurationsService) {}
+    @Inject(ConfigurationsService) private readonly _configurationService: ConfigurationsService,
+    private readonly _redisService: RedisService) {}
 
   @Get()
   getHello(): string {
@@ -16,6 +18,11 @@ export class AppController {
   @Get('/connection-string')
   getConnectionStringV1(): string {
     return this._configurationService.getConnectionStringV1();
+  }
+
+  @Get('redis/ping')
+  async pingRedis(): Promise<string> {
+    return await this._redisService.ping();
   }
   
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Inject } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ConfigurationsService } from './building-blocks/infra/configurations/configurations.service';
+import { RedisService12 } from './building-blocks/infra/redis/redis12.service';
 import { RedisService } from './building-blocks/infra/redis/redis.service';
 
 @Controller()
@@ -8,7 +9,9 @@ export class AppController {
   constructor(
     private readonly appService: AppService,
     @Inject(ConfigurationsService) private readonly _configurationService: ConfigurationsService,
-    private readonly _redisService: RedisService) {}
+    private readonly _redisService: RedisService,
+    private readonly _redisService12: RedisService12
+  ) {}
 
   @Get()
   getHello(): string {
@@ -23,6 +26,11 @@ export class AppController {
   @Get('redis/ping')
   async pingRedis(): Promise<string> {
     return await this._redisService.ping();
+  }
+
+  @Get('redis12/ping')
+  async pingRedis12(): Promise<string> {
+    return await this._redisService12.ping();
   }
   
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ConfigurationsModule } from '@building-blocks/infra/configurations/conf
 import { ProjectsModule } from '@projects/projects.module';
 import { ProjectsModuleDataSource } from '@projects/persistence';
 import { RedisModule } from './building-blocks/infra/redis/redis.module';
+import { RedisModule12 } from './building-blocks/infra/redis/redis12.module';
 
 
 const infrastructureModules = [
@@ -18,6 +19,7 @@ const infrastructureModules = [
     ]
   }),
   RedisModule.register(),
+  RedisModule12.register(),
   ConfigurationsModule
 ];
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,26 +8,32 @@ import { DatabaseModule } from '@building-blocks/infra/database/database.module'
 import { ConfigurationsModule } from '@building-blocks/infra/configurations/configurations.module';
 import { ProjectsModule } from '@projects/projects.module';
 import { ProjectsModuleDataSource } from '@projects/persistence';
-import { CachingModule } from './building-blocks/infra/caching/caching.module';
-import { CachingProvider } from './building-blocks/infra/caching/caching.provider';
+import { RedisModule } from './building-blocks/infra/redis/redis.module';
 
+
+const infrastructureModules = [
+  DatabaseModule.register({
+    migrations: [
+      ...ProjectsModuleDataSource.Migrations
+    ]
+  }),
+  RedisModule.register(),
+  ConfigurationsModule
+];
+
+const featureModules = [
+  ProjectsModule
+];
 
 @Module({
   imports: [
     CqrsModule.forRoot(),
     ConfigModule.forRoot({ isGlobal: true }),
-    ConfigurationsModule,
-    DatabaseModule.register({
-      migrations: [
-        ...ProjectsModuleDataSource.Migrations
-      ]
-    }),
-    CachingModule.register(),
-    ProjectsModule,
-    
+    ...infrastructureModules,
+    ...featureModules
   ],
   controllers: [AppController],
-  providers: [ AppService, CachingProvider ],
+  providers: [ AppService ],
 })
 export class AppModule {
   

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,8 @@ import { DatabaseModule } from '@building-blocks/infra/database/database.module'
 import { ConfigurationsModule } from '@building-blocks/infra/configurations/configurations.module';
 import { ProjectsModule } from '@projects/projects.module';
 import { ProjectsModuleDataSource } from '@projects/persistence';
+import { CachingModule } from './building-blocks/infra/caching/caching.module';
+import { CachingProvider } from './building-blocks/infra/caching/caching.provider';
 
 
 @Module({
@@ -20,10 +22,12 @@ import { ProjectsModuleDataSource } from '@projects/persistence';
         ...ProjectsModuleDataSource.Migrations
       ]
     }),
+    CachingModule.register(),
     ProjectsModule,
+    
   ],
   controllers: [AppController],
-  providers: [ AppService ],
+  providers: [ AppService, CachingProvider ],
 })
 export class AppModule {
   

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ProjectsModule } from '@projects/projects.module';
 import { ProjectsModuleDataSource } from '@projects/persistence';
 import { RedisModule } from './building-blocks/infra/redis/redis.module';
 import { RedisModule12 } from './building-blocks/infra/redis/redis12.module';
+import { CachingModule } from './building-blocks/infra/caching/caching.module';
 
 
 const infrastructureModules = [
@@ -18,6 +19,7 @@ const infrastructureModules = [
       ...ProjectsModuleDataSource.Migrations
     ]
   }),
+  CachingModule.register(),
   RedisModule.register(),
   RedisModule12.register(),
   ConfigurationsModule

--- a/src/building-blocks/infra/caching/caching.module.ts
+++ b/src/building-blocks/infra/caching/caching.module.ts
@@ -1,0 +1,41 @@
+import { CacheModule } from '@nestjs/cache-manager';
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CachingProvider } from './caching.provider';
+import { redisStore } from 'cache-manager-redis-yet';
+
+@Global()
+@Module({})
+export class CachingModule {
+
+    public static register() : DynamicModule {
+
+        const cacheDynamicModule: DynamicModule = CacheModule.registerAsync({
+            isGlobal: true,
+            inject: [ ConfigService ],
+            useFactory: async(configService: ConfigService) => {
+                return ({
+                    store: configService.get<string>("REDIS_ENABLED")?.toLowerCase() === 'false' 
+                        ? 'memory'
+                        : await redisStore({
+                            // url: configService.get<string>("REDIS_URL"),
+                            // host: configService.get<string>(""),
+                            username: configService.get<string>("REDIS_USERNAME"),
+                            password: configService.get<string>("REDIS_PASSWORD"),
+                            socket: {
+                                host: configService.get<string>("REDIS_HOST"),
+                                port: configService.get<number>("REDIS_PORT")
+                            }
+                        })
+                });
+            }
+        });
+
+        return {
+            module: CachingModule,
+            imports: [ cacheDynamicModule ],
+            providers: [ CachingProvider ],
+            exports: [ CachingProvider ]
+        };
+    }
+}

--- a/src/building-blocks/infra/caching/caching.module.ts
+++ b/src/building-blocks/infra/caching/caching.module.ts
@@ -15,17 +15,17 @@ export class CachingModule {
             inject: [ ConfigService ],
             useFactory: async(configService: ConfigService) => {
                 return ({
-                    store: configService.get<string>("REDIS_ENABLED")?.toLowerCase() === 'false' 
-                        ? 'memory'
-                        : await redisStore({
-                            // url: configService.get<string>("REDIS_URL"),
-                            // host: configService.get<string>(""),
-                            username: configService.get<string>("REDIS_USERNAME"),
-                            password: configService.get<string>("REDIS_PASSWORD"),
-                            socket: {
-                                host: configService.get<string>("REDIS_HOST"),
-                                port: configService.get<number>("REDIS_PORT")
-                            }
+                    store: await redisStore({
+                                url: configService.get<string>("REDIS_URL"),
+                                username: configService.get<string>("REDIS_USERNAME"),
+                                password: configService.get<string>("REDIS_PASSWORD"),
+                                disableOfflineQueue: true,
+                                pingInterval: 5 * 60 * 1000,
+                                socket: {
+                                    // host: configService.get<string>("REDIS_HOST"),
+                                    // port: configService.get<number>("REDIS_PORT"),
+                                    tls: false
+                                },
                         })
                 });
             }

--- a/src/building-blocks/infra/caching/caching.provider.ts
+++ b/src/building-blocks/infra/caching/caching.provider.ts
@@ -1,12 +1,16 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 
 @Injectable()
-export class CachingProvider {
+export class CachingProvider implements OnModuleDestroy {
     constructor(
-        @Inject(CACHE_MANAGER) private readonly _cacheManager: Cache
+        @Inject(CACHE_MANAGER) private readonly _cacheManager: Cache,
     ){}
+
+    async onModuleDestroy() {
+        await (this._cacheManager.store as any)?.client?.quit();
+    }
 
     public async setValue<T>(key: string, value: T, ttl?: number) : Promise<void> {
         await this._cacheManager.set(key, value, ttl);

--- a/src/building-blocks/infra/caching/caching.provider.ts
+++ b/src/building-blocks/infra/caching/caching.provider.ts
@@ -1,0 +1,39 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+
+@Injectable()
+export class CachingProvider {
+    constructor(
+        @Inject(CACHE_MANAGER) private readonly _cacheManager: Cache
+    ){}
+
+    public async set<T>(key: string, callback: () => Promise<T>, ttl?: number) : Promise<T> {
+        const value = await callback;
+        await this._cacheManager.set(key, value, ttl);
+        return value as T;
+    }
+
+    public async get<T>(key: string) : Promise<T> {
+        return await this._cacheManager.get<T>(key);
+    }
+
+    public async remove(key: string) : Promise<void> {
+        await this._cacheManager.del(key);
+    }
+
+    // public async replace(key: string, callback: () => any, ttl?: number) : Promise<void> {
+    //     await this.remove(key);
+    //     await this.set(key, callback, ttl);
+    // }
+
+    public async getOrSetIfMissing<T>(key: string, callback: () => Promise<T>, ttl?: number) : Promise<T> {
+        let valueFromCache = await this.get<T>(key);
+
+        if (valueFromCache) {
+            return valueFromCache;
+        }
+
+        return await this.set(key, callback, ttl);
+    }
+}

--- a/src/building-blocks/infra/caching/caching.provider.ts
+++ b/src/building-blocks/infra/caching/caching.provider.ts
@@ -8,10 +8,14 @@ export class CachingProvider {
         @Inject(CACHE_MANAGER) private readonly _cacheManager: Cache
     ){}
 
-    public async set<T>(key: string, callback: () => Promise<T>, ttl?: number) : Promise<T> {
-        const value = await callback;
+    public async setValue<T>(key: string, value: T, ttl?: number) : Promise<void> {
         await this._cacheManager.set(key, value, ttl);
-        return value as T;
+    }
+
+    public async set<T>(key: string, valueFn: Promise<T>, ttl?: number) : Promise<T> {
+        const value = await valueFn;
+        await this._cacheManager.set(key, value, ttl);
+        return value;
     }
 
     public async get<T>(key: string) : Promise<T> {
@@ -22,18 +26,18 @@ export class CachingProvider {
         await this._cacheManager.del(key);
     }
 
-    // public async replace(key: string, callback: () => any, ttl?: number) : Promise<void> {
-    //     await this.remove(key);
-    //     await this.set(key, callback, ttl);
-    // }
+    public async replace<T>(key: string, valueFn: Promise<T>, ttl?: number) : Promise<T> {
+        await this.remove(key);
+        return this.set(key, valueFn, ttl);
+    }
 
-    public async getOrSetIfMissing<T>(key: string, callback: () => Promise<T>, ttl?: number) : Promise<T> {
+    public async getOrSetIfMissing<T>(key: string, valueFn: Promise<T>, ttl?: number) : Promise<T> {
         let valueFromCache = await this.get<T>(key);
 
         if (valueFromCache) {
             return valueFromCache;
         }
 
-        return await this.set(key, callback, ttl);
+        return await this.set(key, valueFn, ttl);
     }
 }

--- a/src/building-blocks/infra/redis/redis.module.ts
+++ b/src/building-blocks/infra/redis/redis.module.ts
@@ -1,0 +1,34 @@
+import { DynamicModule, FactoryProvider, Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient } from 'redis';
+import { RedisService } from './redis.service';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+export type RedisClient = ReturnType<typeof createClient>;
+
+@Module({})
+export class RedisModule {
+    public static register(): DynamicModule {
+
+        const redisClientFactory: FactoryProvider<Promise<RedisClient>> = {
+            provide: REDIS_CLIENT,
+            inject: [ConfigService],
+            useFactory: async (configService: ConfigService) => {
+                const client = createClient({
+                    url: configService.get<string>('REDIS_URL'),
+                    database: 0,
+                    socket: {
+                        tls: false
+                    }
+                });
+                return client;
+            },
+        };
+
+        return {
+            module: RedisModule,
+            providers: [ redisClientFactory, RedisService ],
+            exports: [ RedisService ],
+        };
+    }
+}

--- a/src/building-blocks/infra/redis/redis.module.ts
+++ b/src/building-blocks/infra/redis/redis.module.ts
@@ -5,6 +5,10 @@ import { RedisService } from "./redis.service";
 
 export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
 
+/*
+yarn add ioredis -D
+*/
+
 @Module({})
 export class RedisModule {
     public static register(): DynamicModule {

--- a/src/building-blocks/infra/redis/redis.module.ts
+++ b/src/building-blocks/infra/redis/redis.module.ts
@@ -1,34 +1,37 @@
-import { DynamicModule, FactoryProvider, Global, Module } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { createClient } from 'redis';
-import { RedisService } from './redis.service';
+import { DynamicModule, FactoryProvider, Module } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Redis } from "ioredis";
+import { RedisService } from "./redis.service";
 
 export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
-export type RedisClient = ReturnType<typeof createClient>;
 
 @Module({})
 export class RedisModule {
     public static register(): DynamicModule {
 
-        const redisClientFactory: FactoryProvider<Promise<RedisClient>> = {
+        const redisClientFactory: FactoryProvider<Promise<Redis>> = {
             provide: REDIS_CLIENT,
             inject: [ConfigService],
             useFactory: async (configService: ConfigService) => {
-                const client = createClient({
-                    url: configService.get<string>('REDIS_URL'),
-                    database: 0,
-                    socket: {
-                        tls: false
-                    }
+                const client = new Redis({
+                    host: configService.get('REDIS_HOST'),
+                    port: configService.get('REDIS_PORT'),
+                    db: 0,
+                    keepAlive: 1000,
+                    connectTimeout: 2000
+                })
+                .on('error', (error) => {
+                    console.error(error);
                 });
+
                 return client;
             },
-        };
+        }; 
 
         return {
             module: RedisModule,
-            providers: [ redisClientFactory, RedisService ],
-            exports: [ RedisService ],
+            providers: [redisClientFactory, RedisService],
+            exports: [RedisService],
         };
     }
 }

--- a/src/building-blocks/infra/redis/redis.service.ts
+++ b/src/building-blocks/infra/redis/redis.service.ts
@@ -1,21 +1,16 @@
-import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Redis } from 'ioredis';
 import { REDIS_CLIENT } from './redis.module';
 
 @Injectable()
-export class RedisService implements OnModuleInit, OnModuleDestroy {
+export class RedisService implements OnModuleDestroy {
 
     public constructor(
-        // @Inject(REDIS_CLIENT) private readonly redis: RedisClient,
         @Inject(REDIS_CLIENT) private readonly redis: Redis,
       ) {}
 
-    onModuleInit() {
-        // this.redis.connect();
-    }
-
-    onModuleDestroy() {
-        this.redis.quit();
+    async onModuleDestroy() {
+        await this.redis.quit();
     }
 
     public async ping(): Promise<string> {

--- a/src/building-blocks/infra/redis/redis.service.ts
+++ b/src/building-blocks/infra/redis/redis.service.ts
@@ -1,15 +1,18 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { REDIS_CLIENT, RedisClient } from './redis.module';
+// import { REDIS_CLIENT, RedisClient } from './redis__.module';
+import { Redis } from 'ioredis';
+import { REDIS_CLIENT } from './redis.module';
 
 @Injectable()
 export class RedisService implements OnModuleInit, OnModuleDestroy {
 
     public constructor(
-        @Inject(REDIS_CLIENT) private readonly redis: RedisClient,
+        // @Inject(REDIS_CLIENT) private readonly redis: RedisClient,
+        @Inject(REDIS_CLIENT) private readonly redis: Redis,
       ) {}
 
     onModuleInit() {
-        this.redis.connect();
+        // this.redis.connect();
     }
 
     onModuleDestroy() {

--- a/src/building-blocks/infra/redis/redis.service.ts
+++ b/src/building-blocks/infra/redis/redis.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-// import { REDIS_CLIENT, RedisClient } from './redis__.module';
 import { Redis } from 'ioredis';
 import { REDIS_CLIENT } from './redis.module';
 

--- a/src/building-blocks/infra/redis/redis.service.ts
+++ b/src/building-blocks/infra/redis/redis.service.ts
@@ -1,0 +1,33 @@
+import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { REDIS_CLIENT, RedisClient } from './redis.module';
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+
+    public constructor(
+        @Inject(REDIS_CLIENT) private readonly redis: RedisClient,
+      ) {}
+
+    onModuleInit() {
+        this.redis.connect();
+    }
+
+    onModuleDestroy() {
+        this.redis.quit();
+    }
+
+    public async ping(): Promise<string> {
+        return await this.redis.ping();
+    }
+
+    public async set<T>(key: string, value: T): Promise<T> {
+        await this.redis.set(key, Buffer.from(JSON.stringify(value)));
+        return value;
+    }
+
+    public async get<T>(key: string): Promise<T | null> {
+        const value = await this.redis.get(key);
+        return value ? JSON.parse(value) : null;
+    }
+
+}

--- a/src/building-blocks/infra/redis/redis12.module.ts
+++ b/src/building-blocks/infra/redis/redis12.module.ts
@@ -1,32 +1,28 @@
 import { DynamicModule, FactoryProvider, Global, LoggerService, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient } from 'redis';
-import { RedisService } from './redis.service';
+import { RedisService12 } from './redis12.service';
 
-export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+export const REDIS_CLIENT_12 = Symbol('REDIS_CLIENT_12');
 export type RedisClient = ReturnType<typeof createClient>;
+
+/*
+yarn add redis -D
+*/
 
 @Module({})
 export class RedisModule12 {
     public static register(): DynamicModule {
 
         const redisClientFactory: FactoryProvider<Promise<RedisClient>> = {
-            provide: REDIS_CLIENT,
+            provide: REDIS_CLIENT_12,
             inject: [ConfigService],
             useFactory: async (configService: ConfigService) => {
                 const client = createClient({
                     url: configService.get<string>('REDIS_URL'),
-                    pingInterval: 1000,
-                    // legacyMode: true,
-                    // database: 0,
-                    // socket: {
-                    //     tls: false,
-                    //     host: configService.get<string>('REDIS_HOST'),
-                    //     port: configService.get<number>('REDIS_PORT'),
-                    // }
-                });
-
-                client.on('error', (error) => {
+                    database: 0,
+                })
+                .on('error', (error) => {
                     console.error(error);
                 });
 
@@ -36,8 +32,8 @@ export class RedisModule12 {
 
         return {
             module: RedisModule12,
-            providers: [ redisClientFactory, RedisService ],
-            exports: [ RedisService ],
+            providers: [ redisClientFactory, RedisService12 ],
+            exports: [ RedisService12 ],
         };
     }
 }

--- a/src/building-blocks/infra/redis/redis12.service.ts
+++ b/src/building-blocks/infra/redis/redis12.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { REDIS_CLIENT_12, RedisClient } from './redis12.module';
+
+@Injectable()
+export class RedisService12 implements OnModuleInit, OnModuleDestroy {
+
+    constructor(
+        @Inject(REDIS_CLIENT_12) private readonly _redisClient: RedisClient,
+    ) {}
+
+    async onModuleDestroy() {
+        await this._redisClient.quit();
+    }
+
+    async onModuleInit() {
+        await this._redisClient.connect();
+    }
+
+    public async ping(): Promise<string> {
+        return await this._redisClient.ping();
+    }
+
+    public async set<T>(key: string, value: T): Promise<T> {
+        await this._redisClient.set(key, Buffer.from(JSON.stringify(value)));
+        return value;
+    }
+
+    public async get<T>(key: string): Promise<T | null> {
+        const value = await this._redisClient.get(key);
+        return value ? JSON.parse(value) : null;
+    }
+}

--- a/src/building-blocks/infra/redis/redis__.module.ts
+++ b/src/building-blocks/infra/redis/redis__.module.ts
@@ -1,0 +1,43 @@
+import { DynamicModule, FactoryProvider, Global, LoggerService, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient } from 'redis';
+import { RedisService } from './redis.service';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+export type RedisClient = ReturnType<typeof createClient>;
+
+@Module({})
+export class RedisModule12 {
+    public static register(): DynamicModule {
+
+        const redisClientFactory: FactoryProvider<Promise<RedisClient>> = {
+            provide: REDIS_CLIENT,
+            inject: [ConfigService],
+            useFactory: async (configService: ConfigService) => {
+                const client = createClient({
+                    url: configService.get<string>('REDIS_URL'),
+                    pingInterval: 1000,
+                    // legacyMode: true,
+                    // database: 0,
+                    // socket: {
+                    //     tls: false,
+                    //     host: configService.get<string>('REDIS_HOST'),
+                    //     port: configService.get<number>('REDIS_PORT'),
+                    // }
+                });
+
+                client.on('error', (error) => {
+                    console.error(error);
+                });
+
+                return client;
+            },
+        };
+
+        return {
+            module: RedisModule12,
+            providers: [ redisClientFactory, RedisService ],
+            exports: [ RedisService ],
+        };
+    }
+}

--- a/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
+++ b/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
@@ -4,22 +4,34 @@ import { FindByIdResponse } from "./find-by-id.response";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Project } from "@projects/core/project";
 import { Repository } from "typeorm";
+import { Inject } from "@nestjs/common";
+import { CachingProvider } from "@src/building-blocks/infra/caching/caching.provider";
 
 @QueryHandler(FindByIdRequest)
 export class FindByIdHandler implements IQueryHandler<FindByIdRequest, FindByIdResponse> {
 
     constructor(
-        @InjectRepository(Project) private readonly _projectRepository: Repository<Project>
+        @InjectRepository(Project) private readonly _projectRepository: Repository<Project>,
+        @Inject(CachingProvider) private readonly _cacheProvider: CachingProvider
     ){}
 
     async execute(query: FindByIdRequest): Promise<FindByIdResponse> {
 
-        const project = await this._projectRepository.findOne({
-            relations: {
-                tasks: true
-            },
-            where: { id: query.id }
-        });
+        const taskGetProject = this._projectRepository.findOne({
+                relations: {
+                    tasks: true
+                },
+                where: { id: query.id }
+            });
+
+        const project = await this._cacheProvider.getOrSetIfMissing(`project-${query.id}`, taskGetProject);
+
+        // const project = await this._projectRepository.findOne({
+        //     relations: {
+        //         tasks: true
+        //     },
+        //     where: { id: query.id }
+        // });
         
         return new FindByIdResponse(project);
     }

--- a/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
+++ b/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
@@ -24,7 +24,8 @@ export class FindByIdHandler implements IQueryHandler<FindByIdRequest, FindByIdR
                 where: { id: query.id }
             });
 
-        const project = await this._cacheProvider.getOrSetIfMissing(`project-${query.id}`, taskGetProject);
+        const project = await this._cacheProvider
+                .getOrSetIfMissing<Project>(`project-${query.id}`, taskGetProject, 60);
 
         // const project = await this._projectRepository.findOne({
         //     relations: {

--- a/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
+++ b/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
@@ -4,35 +4,32 @@ import { FindByIdResponse } from "./find-by-id.response";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Project } from "@projects/core/project";
 import { Repository } from "typeorm";
-import { Inject } from "@nestjs/common";
-import { CachingProvider } from "@src/building-blocks/infra/caching/caching.provider";
 
 @QueryHandler(FindByIdRequest)
 export class FindByIdHandler implements IQueryHandler<FindByIdRequest, FindByIdResponse> {
 
     constructor(
         @InjectRepository(Project) private readonly _projectRepository: Repository<Project>,
-        @Inject(CachingProvider) private readonly _cacheProvider: CachingProvider
     ){}
 
     async execute(query: FindByIdRequest): Promise<FindByIdResponse> {
 
-        const taskGetProject = this._projectRepository.findOne({
-                relations: {
-                    tasks: true
-                },
-                where: { id: query.id }
-            });
+        // const taskGetProject = this._projectRepository.findOne({
+        //         relations: {
+        //             tasks: true
+        //         },
+        //         where: { id: query.id }
+        //     });
 
-        const project = await this._cacheProvider
-                .getOrSetIfMissing<Project>(`project-${query.id}`, taskGetProject, 60);
+        // const project = await this._cacheProvider
+        //         .getOrSetIfMissing<Project>(`project-${query.id}`, taskGetProject, 60);
 
-        // const project = await this._projectRepository.findOne({
-        //     relations: {
-        //         tasks: true
-        //     },
-        //     where: { id: query.id }
-        // });
+        const project = await this._projectRepository.findOne({
+            relations: {
+                tasks: true
+            },
+            where: { id: query.id }
+        });
         
         return new FindByIdResponse(project);
     }

--- a/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
+++ b/src/projects/use-cases/project/queries/find-by-id/find-by-id.handler.ts
@@ -4,32 +4,34 @@ import { FindByIdResponse } from "./find-by-id.response";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Project } from "@projects/core/project";
 import { Repository } from "typeorm";
+import { CachingProvider } from "@src/building-blocks/infra/caching/caching.provider";
 
 @QueryHandler(FindByIdRequest)
 export class FindByIdHandler implements IQueryHandler<FindByIdRequest, FindByIdResponse> {
 
     constructor(
         @InjectRepository(Project) private readonly _projectRepository: Repository<Project>,
+        private readonly _cacheProvider: CachingProvider
     ){}
 
     async execute(query: FindByIdRequest): Promise<FindByIdResponse> {
 
-        // const taskGetProject = this._projectRepository.findOne({
-        //         relations: {
-        //             tasks: true
-        //         },
-        //         where: { id: query.id }
-        //     });
+        const taskGetProject = this._projectRepository.findOne({
+                relations: {
+                    tasks: true
+                },
+                where: { id: query.id }
+            });
 
-        // const project = await this._cacheProvider
-        //         .getOrSetIfMissing<Project>(`project-${query.id}`, taskGetProject, 60);
+        const project = await this._cacheProvider
+                .getOrSetIfMissing<Project>(`project-${query.id}`, taskGetProject, 60);
 
-        const project = await this._projectRepository.findOne({
-            relations: {
-                tasks: true
-            },
-            where: { id: query.id }
-        });
+        // const project = await this._projectRepository.findOne({
+        //     relations: {
+        //         tasks: true
+        //     },
+        //     where: { id: query.id }
+        // });
         
         return new FindByIdResponse(project);
     }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -16,4 +16,11 @@ describe('AppController (e2e)', () => {
         expect(response.text).toBe(connectionString)
         expect(process.env.DATABASE_URL).toBe(connectionString);
     });
+
+    test("/redis/ping (GET)", async () => {
+        const response = await request(httpServer).get("/redis/ping");
+
+        expect(response.status).toBe(HttpStatus.OK);
+        expect(response.text).toBe("PONG");
+    });
 });

--- a/test/projects/findById.e2e-spec.ts
+++ b/test/projects/findById.e2e-spec.ts
@@ -40,13 +40,11 @@ describe('ProjectsContoller (e2e)', () => {
       expect(taskPayload).toBeDefined();
     });
 
-    // const cachingProvider = app.get<CachingProvider>(CachingProvider);
-    // const cachedProject = await cachingProvider.get<Project>(`project-${project.id}`);
+    const cachingProvider = app.get<CachingProvider>(CachingProvider);
+    const cachedProject = await cachingProvider.get<Project>(`project-${project.id}`);
 
-    // const redisService = app.get<RedisService>(REDIS_CLIENT);
-    // const cachedProject = await redisService.get<Project>(`project-${project.id}`);
-    // console.log(`cachedProject: ${JSON.stringify(cachedProject)}`);
-    // expect(cachedProject).toMatchObject({ id: project.id, name: project.name });
+    console.log(`cachedProject: ${JSON.stringify(cachedProject)}`);
+    expect(cachedProject).toMatchObject({ id: project.id, name: project.name });
     
   });
 

--- a/test/projects/findById.e2e-spec.ts
+++ b/test/projects/findById.e2e-spec.ts
@@ -6,6 +6,8 @@ import { Project } from '@src/projects/core/project';
 import { app, httpServer } from '@test/test.setup';
 import { faker } from '@faker-js/faker';
 import { CachingProvider } from '@src/building-blocks/infra/caching/caching.provider';
+import { RedisService } from '@src/building-blocks/infra/redis/redis.service';
+import { REDIS_CLIENT } from '@src/building-blocks/infra/redis/redis.module';
 
 describe('ProjectsContoller (e2e)', () => {
   let project: Project;
@@ -38,10 +40,13 @@ describe('ProjectsContoller (e2e)', () => {
       expect(taskPayload).toBeDefined();
     });
 
-    const cachingProvider = app.get<CachingProvider>(CachingProvider);
-    const cachedProject = await cachingProvider.get<Project>(`project-${project.id}`);
-    console.log(`cachedProject: ${JSON.stringify(cachedProject)}`);
-    expect(cachedProject).toMatchObject({ id: project.id, name: project.name });
+    // const cachingProvider = app.get<CachingProvider>(CachingProvider);
+    // const cachedProject = await cachingProvider.get<Project>(`project-${project.id}`);
+
+    // const redisService = app.get<RedisService>(REDIS_CLIENT);
+    // const cachedProject = await redisService.get<Project>(`project-${project.id}`);
+    // console.log(`cachedProject: ${JSON.stringify(cachedProject)}`);
+    // expect(cachedProject).toMatchObject({ id: project.id, name: project.name });
     
   });
 

--- a/test/projects/findById.e2e-spec.ts
+++ b/test/projects/findById.e2e-spec.ts
@@ -5,6 +5,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Project } from '@src/projects/core/project';
 import { app, httpServer } from '@test/test.setup';
 import { faker } from '@faker-js/faker';
+import { CachingProvider } from '@src/building-blocks/infra/caching/caching.provider';
 
 describe('ProjectsContoller (e2e)', () => {
   let project: Project;
@@ -36,6 +37,11 @@ describe('ProjectsContoller (e2e)', () => {
       const taskPayload = project.tasks.find(t => t.name === task.name);
       expect(taskPayload).toBeDefined();
     });
+
+    const cachingProvider = app.get<CachingProvider>(CachingProvider);
+    const cachedProject = await cachingProvider.get<Project>(`project-${project.id}`);
+    console.log(`cachedProject: ${JSON.stringify(cachedProject)}`);
+    expect(cachedProject).toMatchObject({ id: project.id, name: project.name });
     
   });
 

--- a/test/test-infra/cache12.e2e-spec.ts
+++ b/test/test-infra/cache12.e2e-spec.ts
@@ -1,0 +1,26 @@
+import { faker } from "@faker-js/faker";
+import { RedisService12 } from "@src/building-blocks/infra/redis/redis12.service";
+import { app } from "@test/test.setup";
+
+
+
+describe("Test - Caching", () => {
+    let redisService: RedisService12;
+
+    const cacheKey = faker.string.uuid();
+    const cacheObjects = faker.helpers.multiple(() => ({
+        id: faker.string.uuid(),
+        name: faker.person.fullName()
+    }), { count: 5 });
+    
+    beforeEach(async () => {
+        redisService = app.get<RedisService12>(RedisService12);
+        await redisService.set(cacheKey, cacheObjects);
+    });
+
+    it("Setup Caching Provider", async () => {
+        const objectsFromCache = await redisService.get(cacheKey);
+        expect(objectsFromCache).toEqual(cacheObjects);
+    });
+
+});

--- a/test/test-infra/caching.e2e-spec.ts
+++ b/test/test-infra/caching.e2e-spec.ts
@@ -1,25 +1,27 @@
 import { faker } from "@faker-js/faker";
-import { CachingProvider } from "@src/building-blocks/infra/caching/caching.provider";
+import { REDIS_CLIENT } from "@src/building-blocks/infra/redis/redis.module";
+import { RedisService } from "@src/building-blocks/infra/redis/redis.service";
 import { app } from "@test/test.setup";
 
 
 
 describe("Test - Caching", () => {
-    let cachingProvider: CachingProvider;
-    
-    let cachedObject = {
+    let redisService: RedisService;
+
+    const cacheKey = faker.string.uuid();
+    const cacheObjects = faker.helpers.multiple(() => ({
         id: faker.string.uuid(),
         name: faker.person.fullName()
-    };
-
+    }), { count: 5 });
+    
     beforeEach(async () => {
-        cachingProvider = app.get<CachingProvider>(CachingProvider);
-        await cachingProvider.setValue(cachedObject.id, cachedObject);
+        redisService = app.get<RedisService>(RedisService);
+        await redisService.set(cacheKey, cacheObjects);
     });
 
     it("Setup Caching Provider", async () => {
-        const value = await cachingProvider.get(cachedObject.id);
-        expect(value).toEqual(cachedObject);
+        const objectsFromCache = await redisService.get(cacheKey);
+        expect(objectsFromCache).toEqual(cacheObjects);
     });
 
 });

--- a/test/test-infra/caching.e2e-spec.ts
+++ b/test/test-infra/caching.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { faker } from "@faker-js/faker";
+import { CachingProvider } from "@src/building-blocks/infra/caching/caching.provider";
+import { app } from "@test/test.setup";
+
+
+
+describe("Test - Caching", () => {
+    let cachingProvider: CachingProvider;
+    
+    let cachedObject = {
+        id: faker.string.uuid(),
+        name: faker.person.fullName()
+    };
+
+    beforeEach(async () => {
+        cachingProvider = app.get<CachingProvider>(CachingProvider);
+        await cachingProvider.setValue(cachedObject.id, cachedObject);
+    });
+
+    it("Setup Caching Provider", async () => {
+        const value = await cachingProvider.get(cachedObject.id);
+        expect(value).toEqual(cachedObject);
+    });
+
+});

--- a/test/test-infra/caching.e2e-spec.ts
+++ b/test/test-infra/caching.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import { REDIS_CLIENT } from "@src/building-blocks/infra/redis/redis.module";
 import { RedisService } from "@src/building-blocks/infra/redis/redis.service";
 import { app } from "@test/test.setup";
 

--- a/test/test.setup.ts
+++ b/test/test.setup.ts
@@ -1,27 +1,40 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
 import { AppModule } from '@src/app.module';
 import { Wait } from 'testcontainers';
 
 let postgresContainer: StartedPostgreSqlContainer;
+let redisContainer: StartedRedisContainer;
 let app: INestApplication;
 let connectionString: string;
 let httpServer: any;
 
 
-global.beforeAll(async () => {
+beforeAll(async () => {
 
     postgresContainer = await new PostgreSqlContainer("postgres:alpine")
             .withDatabase("practical-nestjs-testing")
             .withUsername("postgres")
             .withPassword("postgres")
-            .withStartupTimeout(12000)
+            .withStartupTimeout(8000)
             .withWaitStrategy(Wait.forListeningPorts())
+            .withNetworkAliases("practical-nestjs-network")
             .start();
 
+    redisContainer = await new RedisContainer("redis:alpine")
+        .withStartupTimeout(8000)
+        .withNetworkAliases("practical-nestjs-network")
+        .start();
+
     connectionString = postgresContainer.getConnectionUri();
+
     process.env.DATABASE_URL = connectionString;
+
+    process.env.REDIS_URL = redisContainer.getConnectionUrl();
+    process.env.REDIS_HOST = redisContainer.getHost();
+    process.env.REDIS_PORT = redisContainer.getPort().toString();
 
     const moduleFixture:TestingModule = await Test.createTestingModule({
         imports: [ AppModule ]
@@ -35,15 +48,23 @@ global.beforeAll(async () => {
     await app.init();
 
     httpServer = app.getHttpServer();
-})
+});
 
-global.afterAll(async () => {
-    await postgresContainer?.stop({
-        timeout:8000,
+
+
+afterAll(async () => {
+    await redisContainer.stop({
+        remove: true,
+        removeVolumes: true,
+    });
+
+    await postgresContainer.stop({
         remove: true,
         removeVolumes: true
     });
+
     await app.close();
+    
 });
 
 // add some timeout until containers are up and working 

--- a/test/test.setup.ts
+++ b/test/test.setup.ts
@@ -4,9 +4,6 @@ import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers
 import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
 import { AppModule } from '@src/app.module';
 import { Wait } from 'testcontainers';
-import { RedisService } from '@src/building-blocks/infra/redis/redis.service';
-import { REDIS_CLIENT, RedisModule } from '@src/building-blocks/infra/redis/redis.module';
-import { Redis } from 'ioredis';
 
 let postgresContainer: StartedPostgreSqlContainer;
 let redisContainer: StartedRedisContainer;
@@ -26,7 +23,7 @@ beforeAll(async () => {
             .withNetworkAliases("practical-nestjs-network")
             .start();
 
-    redisContainer = await new RedisContainer("redis:latest")
+    redisContainer = await new RedisContainer("redis:alpine")
         .withStartupTimeout(8000)
         .withNetworkAliases("practical-nestjs-network")
         .start();
@@ -69,25 +66,6 @@ afterAll(async () => {
         remove: true,
         removeVolumes: true
     });
-
-    
-
-    // const redis = app.get<Redis>(REDIS_CLIENT);
-    
-    // await redis.quit(async () => {
-    //     await redisContainer.stop({
-    //         remove: true,
-    //         removeVolumes: true,
-    //     });
-    
-    //     await postgresContainer.stop({
-    //         remove: true,
-    //         removeVolumes: true
-    //     });
-    
-    //     await app.close();
-    // })
-    
 });
 
 // add some timeout until containers are up and working 

--- a/test/test.setup.ts
+++ b/test/test.setup.ts
@@ -4,6 +4,8 @@ import { PostgreSqlContainer, StartedPostgreSqlContainer } from '@testcontainers
 import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
 import { AppModule } from '@src/app.module';
 import { Wait } from 'testcontainers';
+import { RedisService } from '@src/building-blocks/infra/redis/redis.service';
+import { REDIS_CLIENT, RedisModule } from '@src/building-blocks/infra/redis/redis.module';
 
 let postgresContainer: StartedPostgreSqlContainer;
 let redisContainer: StartedRedisContainer;
@@ -37,7 +39,7 @@ beforeAll(async () => {
     process.env.REDIS_PORT = redisContainer.getPort().toString();
 
     const moduleFixture:TestingModule = await Test.createTestingModule({
-        imports: [ AppModule ]
+        imports: [ AppModule ],
     })
     .compile();
 
@@ -53,6 +55,7 @@ beforeAll(async () => {
 
 
 afterAll(async () => {
+
     await redisContainer.stop({
         remove: true,
         removeVolumes: true,

--- a/test/test.setup.ts
+++ b/test/test.setup.ts
@@ -6,6 +6,7 @@ import { AppModule } from '@src/app.module';
 import { Wait } from 'testcontainers';
 import { RedisService } from '@src/building-blocks/infra/redis/redis.service';
 import { REDIS_CLIENT, RedisModule } from '@src/building-blocks/infra/redis/redis.module';
+import { Redis } from 'ioredis';
 
 let postgresContainer: StartedPostgreSqlContainer;
 let redisContainer: StartedRedisContainer;
@@ -25,7 +26,7 @@ beforeAll(async () => {
             .withNetworkAliases("practical-nestjs-network")
             .start();
 
-    redisContainer = await new RedisContainer("redis:alpine")
+    redisContainer = await new RedisContainer("redis:latest")
         .withStartupTimeout(8000)
         .withNetworkAliases("practical-nestjs-network")
         .start();
@@ -37,6 +38,7 @@ beforeAll(async () => {
     process.env.REDIS_URL = redisContainer.getConnectionUrl();
     process.env.REDIS_HOST = redisContainer.getHost();
     process.env.REDIS_PORT = redisContainer.getPort().toString();
+    // console.log(`Redis URL: ${process.env.REDIS_URL}`);
 
     const moduleFixture:TestingModule = await Test.createTestingModule({
         imports: [ AppModule ],
@@ -56,6 +58,8 @@ beforeAll(async () => {
 
 afterAll(async () => {
 
+    await app.close();
+    
     await redisContainer.stop({
         remove: true,
         removeVolumes: true,
@@ -66,7 +70,23 @@ afterAll(async () => {
         removeVolumes: true
     });
 
-    await app.close();
+    
+
+    // const redis = app.get<Redis>(REDIS_CLIENT);
+    
+    // await redis.quit(async () => {
+    //     await redisContainer.stop({
+    //         remove: true,
+    //         removeVolumes: true,
+    //     });
+    
+    //     await postgresContainer.stop({
+    //         remove: true,
+    //         removeVolumes: true
+    //     });
+    
+    //     await app.close();
+    // })
     
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,6 +411,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -2115,7 +2120,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
-cluster-key-slot@1.1.2:
+cluster-key-slot@1.1.2, cluster-key-slot@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
@@ -2374,6 +2379,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0:
   version "2.0.0"
@@ -3309,6 +3319,21 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+ioredis@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.4.1.tgz#1c56b70b759f01465913887375ed809134296f40"
+  integrity sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -3983,6 +4008,11 @@ lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -4777,6 +4807,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 redis@^4.6.13:
   version "4.6.13"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.13.tgz#e247267c5f3ba35ab8277b57343d3a56acb2f0a6"
@@ -5110,6 +5152,11 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,13 @@
   dependencies:
     testcontainers "^10.8.2"
 
+"@testcontainers/redis@^10.9.0":
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/@testcontainers/redis/-/redis-10.9.0.tgz#fabc1480b01343f82ea868c2ba5bbea26c73a9f5"
+  integrity sha512-zj0WibTLyLVWzkjLz26q2b8Hx0VnC4+rq7p7Pg+LWqX6ijAfcHCafze27V1wNG7aC/26nH6p5QV0y+34Aq50aw==
+  dependencies:
+    testcontainers "^10.9.0"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -5362,6 +5369,27 @@ testcontainers@^10.8.2:
   version "10.8.2"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-10.8.2.tgz#1e1df0e2d14d44c7ef2737b0e5fe3efb57e8d3c4"
   integrity sha512-9Ink7NUyYZwOjQhk0C6R6basWy2WADNly+md3D9YDap0pcDr3C+vrO8Ah1bkYco/9Zg8VoYTHO+blkLeebBYkA==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    "@types/dockerode" "^3.3.24"
+    archiver "^5.3.2"
+    async-lock "^1.4.1"
+    byline "^5.0.0"
+    debug "^4.3.4"
+    docker-compose "^0.24.6"
+    dockerode "^3.3.5"
+    get-port "^5.1.1"
+    node-fetch "^2.7.0"
+    proper-lockfile "^4.1.2"
+    properties-reader "^2.3.0"
+    ssh-remote-port-forward "^1.0.4"
+    tar-fs "^3.0.5"
+    tmp "^0.2.1"
+
+testcontainers@^10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-10.9.0.tgz#9d5b2ef189ed32a0be376d013017ba8593a09e93"
+  integrity sha512-LN+cKAOd61Up9SVMJW+3VFVGeVQG8JBqZhEQo2U0HBfIsAynyAXcsLBSo+KZrOfy9SBz7pGHctWN/KabLDbNFA==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     "@types/dockerode" "^3.3.24"

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,6 +696,11 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
+"@nestjs/cache-manager@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/cache-manager/-/cache-manager-2.2.2.tgz#4b0e7c4112c7b8c2a869d64f998aaf8a1bf0040d"
+  integrity sha512-+n7rpU1QABeW2WV17Dl1vZCG3vWjJU1MaamWgZvbGxYE9EeCM0lVLfw3z7acgDTNwOy+K68xuQPoIMxD0bhjlA==
+
 "@nestjs/cli@^10.0.0":
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-10.3.2.tgz#42d2764ead6633e278c55d42de871b4cc1db002b"
@@ -854,6 +859,40 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
+
+"@redis/bloom@1.2.0", "@redis/bloom@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.5.14", "@redis/client@^1.5.14":
+  version "1.5.14"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.5.14.tgz#1107893464d092f140d77c468b018a6ed306a180"
+  integrity sha512-YGn0GqsRBFUQxklhY7v562VMOP0DcmlrHHs3IV1mFE3cbxe31IITUkqhBcIhVSI/2JqtWAJXg5mjV4aU+zD0HA==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.1", "@redis/graph@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
+  integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
+
+"@redis/json@1.0.6", "@redis/json@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.6.tgz#b7a7725bbb907765d84c99d55eac3fcf772e180e"
+  integrity sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==
+
+"@redis/search@1.1.6", "@redis/search@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.1.6.tgz#33bcdd791d9ed88ab6910243a355d85a7fedf756"
+  integrity sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==
+
+"@redis/time-series@1.0.5", "@redis/time-series@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.5.tgz#a6d70ef7a0e71e083ea09b967df0a0ed742bc6ad"
+  integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -1867,6 +1906,30 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cache-manager-redis-yet@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cache-manager-redis-yet/-/cache-manager-redis-yet-5.0.0.tgz#79faade1badda2dffc6bb968897ad097a42fae2f"
+  integrity sha512-ooBCA71CVUFPoLBx54vig0zhEe5yLcGDQmy9FGS1lBm0wc/efccC+KHdW9mURbuAtL7bi4mRiDA0bHg1a3Vbhw==
+  dependencies:
+    "@redis/bloom" "^1.2.0"
+    "@redis/client" "^1.5.14"
+    "@redis/graph" "^1.1.1"
+    "@redis/json" "^1.0.6"
+    "@redis/search" "^1.1.6"
+    "@redis/time-series" "^1.0.5"
+    cache-manager "^5.4.0"
+    redis "^4.6.13"
+
+cache-manager@^5.4.0, cache-manager@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-5.5.1.tgz#b86a3995e9c0d2b26f799c6c483fda470a3d5794"
+  integrity sha512-QYZFOjZTTennYdN3NNCKh+yq452+wQ4ChyL40jkEyghIgg5Ugwb4YO8ARIIF1fvTBkgDLlLTYFaxZVaPGmQ92A==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    lodash.clonedeep "^4.5.0"
+    lru-cache "^10.2.0"
+    promise-coalesce "^1.1.2"
+
 call-bind@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
@@ -2044,6 +2107,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -2613,6 +2681,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -2910,6 +2983,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -3879,6 +3957,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -4538,6 +4621,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+promise-coalesce@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/promise-coalesce/-/promise-coalesce-1.1.2.tgz#5d3bc4d0b2cf2e41e9df7cbeb6519b2a09459e3d"
+  integrity sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -4681,6 +4769,18 @@ rechoir@^0.6.2:
   integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
   dependencies:
     resolve "^1.1.6"
+
+redis@^4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.13.tgz#e247267c5f3ba35ab8277b57343d3a56acb2f0a6"
+  integrity sha512-MHgkS4B+sPjCXpf+HfdetBwbRz6vCtsceTmw1pHNYJAsYxrfpOP6dz+piJWGos8wqG7qb3vj/Rrc5qOlmInUuA==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.5.14"
+    "@redis/graph" "1.1.1"
+    "@redis/json" "1.0.6"
+    "@redis/search" "1.1.6"
+    "@redis/time-series" "1.0.5"
 
 reflect-metadata@^0.2.0, reflect-metadata@^0.2.1:
   version "0.2.2"
@@ -5712,15 +5812,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.2.2:
   version "2.4.1"


### PR DESCRIPTION
# Caching-Module
- Ability to use In-Memory or Redis via `CACHE_MANAGER`
- Note: `CachingProvider` implement `OnModuleDestroyed` to `quit` from `Redis`
- The following packages must be installed
```bash
yarn add @nestjs/cache-manager cache-manager cache-manager-redis-yet
```

# Redis-Module
- Ability to use Redis's commands - HGETALL ...
- Use 2 packages separately
```bash
yarn add redis
//or
yarn add ioredis
```

# All
- E2E testing - adding `@testcontainers/redis`
- The order stop must be: 

```TypeScript

app.Close();
redisContainer.Stop();
pgDatabase.Stop();

```
